### PR TITLE
Bump loader-utils from 1.4.1 to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.2 (19.11.2022)
+
+Updated loader-utils to 1.4.2 to resolve some high severity vulnerabilities.
+
+
 ## 2.1.1 (23.10.2020)
 
 Added LICENSE, improved README. Published the package on GitHub.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/scss-imports-loader",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       }
     },
     "loader-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
-      "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/scss-imports-loader",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Global imports for SCSS files",
   "license": "MIT",
   "author": "Igor Adamenko <mail@igoradamenko.com> (https://igoradamenko.com)",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "prepublishOnly": "if [ -z \"$CI\" ]; then lawyer; fi"
   },
   "dependencies": {
-    "loader-utils": "1.4.1"
+    "loader-utils": "1.4.2"
   }
 }


### PR DESCRIPTION
Resolves 2 high severity vulnerabilities. A new patch version has been released recently: https://github.com/webpack/loader-utils/releases/tag/v1.4.2